### PR TITLE
Upgrade GitHub-maintained actions to latest major versions

### DIFF
--- a/.github/workflows/gitterra.yml
+++ b/.github/workflows/gitterra.yml
@@ -34,18 +34,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: gitterra
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "."
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
   add-pr-comment:
     name: Add PR comment with GitTerra map link
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: "bash"
 
     - name: Opening the scrolls of wisdom
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: "scrolls"
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -29,7 +29,7 @@ runs:
 
     - name: Inviting a wizard from a distant land
       id: cache-scc
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: our-wizard
       with:
@@ -46,14 +46,14 @@ runs:
       shell: "bash"
 
     - name: Transporting builders to the construction site
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: "GitTerraGame/Play-GitTerra-Action"
         path: "builders"
 
     - name: Looking for a stash of existing tools
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: tool-stash
       with:
@@ -77,7 +77,7 @@ runs:
     - name: Checking history archives
       if: ${{ inputs.deploy-destination == '' }}
       id: cache-history-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       env:
         cache-name: history
       with:
@@ -100,7 +100,7 @@ runs:
     - name: Updating history archives
       if: ${{ inputs.deploy-destination == '' }}
       id: cache-history-update
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       env:
         cache-name: history
       with:
@@ -111,7 +111,7 @@ runs:
         key: ${{ env.cache-name }}-${{ github.ref }}-${{ hashFiles('history.json') }}
 
     - name: Archive the maps in the player's library
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: gitterra
         path: |


### PR DESCRIPTION
## Summary
Workflow (`.github/workflows/gitterra.yml`):
- `actions/download-artifact` v4 → v8
- `actions/configure-pages` v4 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5

Composite action (`action.yml`):
- `actions/cache/restore` v4 → v5
- `actions/cache/save` v4 → v5
- `actions/upload-artifact` v4 → v7

## Test plan
- [ ] Workflow runs successfully on merge to main
- [ ] Map artifact uploads/downloads still work between jobs
- [ ] Pages deployment completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)